### PR TITLE
Adding argument for freezing vision backbone.

### DIFF
--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -7,6 +7,7 @@ accelerate launch train_phi3v.py \
     --model_id /path/to/Phi-3-vision-128k-instruct \
     --output_dir output/test_train_lora \
     --num_train_epochs 1 \
+    --freeze_vision \
     --per_device_train_batch_size 1 \
     --gradient_accumulation_steps 8 \
     --deepspeed_config scripts/zero2.json \

--- a/train_phi3v.py
+++ b/train_phi3v.py
@@ -41,6 +41,7 @@ parser.add_argument("--lora_alpha", type=int, default=256, help="LoRA alpha.")
 parser.add_argument("--lora_dropout", type=float, default=0.05, help="LoRA dropout.")
 parser.add_argument("--logging_steps", type=int, default=1, help="Logging steps.")
 parser.add_argument("--dataloader_num_workers", type=int, default=4, help="Number of data loader workers.")
+parser.add_argument("--freeze_vision", action='store_true', help="Freeze vision backbone.")
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +263,14 @@ def train():
         quantization_config=quantization_config
     )
     processor = Phi3VProcessor.from_pretrained(args.model_id)
+
+    if args.freeze_vision:
+        for p in model.model.vision_embed_tokens.img_processor.parameters():
+            p.requires_grad = False
+
+    else:
+        for p in model.model.vision_embed_tokens.img_processor.parameters():
+            p.requires_grad = True
 
     if args.quantization:
         model.config.torch_dtype = torch.bfloat16


### PR DESCRIPTION
Unfreezing the vision backbone while fine-tuning could be helpful for when finetuning according to the following tech report.
https://arxiv.org/pdf/2403.06199